### PR TITLE
Bumped up version and kept CHANGELOG up to date

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.1.1
+## 0.1.4
+
+- Add explicit Python version support (including Python 3)
+
+## 0.1.3
 
 - Fixed GetAllMonitors action
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - monitoring
   - alerting
   - saas
-version: 0.1.3
+version: 0.1.4
 author: Lisa Bekdache
 email: lisa.bekdache@dailymotion.com
 python_versions:


### PR DESCRIPTION
Close: #10 

The latest version (v0.1.3) of this pack is tagged at the point that #6
was merged. So it doesn't contain the changes from #7 to #9.And those
changes have not been written at the CHANGELOG.
This PR bumped up version to v0.1.4 and keep track of descriptions of
those features which were merged after v0.1.3 to the CHANGELOG as the
ones of v0.1.4.