### PR TITLE
[bugfix] Update metrics.query_ts_points action with correct class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+* Update metrics.query_ts_points action with the correct class: `DatadogQueryTSPoints` 
+
 ## 1.0.0
 
 * Drop Python 2.7 support

--- a/actions/metrics.query_ts_points.yaml
+++ b/actions/metrics.query_ts_points.yaml
@@ -17,7 +17,7 @@ parameters:
     required: true
     description: "The query string, see http://docs.datadoghq.com/graphing/ for the syntax"
   cls:
-    default: DatadogPostTSPoints
+    default: DatadogQueryTSPoints
     immutable: true
     type: string
   module_path:

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - monitoring
   - alerting
   - saas
-version: 1.0.0
+version: 1.0.1
 author: Lisa Bekdache
 email: lisa.bekdache@dailymotion.com
 python_versions:


### PR DESCRIPTION
Action `metrics.query_ts_points` is pointing to `DatadogPostTSPoints` Class which is incorrect, rather it should be pointing to `DatadogQueryTSPoints`.

_Existing issue while using `metrics.query_ts_points` action:_
Action execution fails with the key error:
```
  File "/opt/stackstorm/packs/datadog/actions/lib/metrics.py", line 7, in _run
    return api.Metric.send(kwargs.pop("series"), **kwargs)
KeyError: 'series'
command terminated with exit code 1
```
Validated that post updating the class, the action execution succeeded 
```
{
  "stdout": "",
  "stderr": "st2.actions.python.PythonActionWrapper: INFO     Loading /opt/stackstorm/packs/datadog/actions/run.py from pack datadog for user arcadia-valve\nst2.actions.python.PythonActionWrapper: INFO     Attempting to run <bound method ActionWrapper.run of <run.ActionWrapper object at 0x7f9f839b9430>>\n",
  "exit_code": 0,
  "result": {
    "status": "ok",
    "res_type": "time_series",
    "resp_version": 1,
    "query": "sum:xyz.offline_partitions_count{kube_namespace:xyz-10}",
    "from_date": 1726503300000,
    "to_date": 1726503500000,
    "series": [
      {
        "unit": null,
        "query_index": 0,
        "aggr": "sum",
        "metric": "xyz.offline_partitions_count",
        "tag_set": [],
        "expression": "sum:xyz.offline_partitions_count{kube_namespace:xyz-10}",
        "scope": "kube_namespace:xyz-10",
        "interval": 1,
        "length": 20,
        "start": 1726503300000,
        "end": 1726503490000,
        "pointlist": [
          [
            1726503300000,
            0
          ],
          ...
          <truncated>
        ],
        "display_name": "xyz.offline_partitions_count",
        "attributes": {}
      }
    ],
    "values": [],
    "times": [],
    "message": "",
    "group_by": []
  },
<truncated>
}
```