### PR TITLE
[bugfix] monitors.get_all_monitors action to filter results based on action parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.2
+
+* Fix `monitors.get_all_monitors` action to filter results based on `group_states` and `monitor_tags` parameters
+
 ## 1.0.1
 
 * Update metrics.query_ts_points action with the correct class: `DatadogQueryTSPoints` 

--- a/actions/lib/base.py
+++ b/actions/lib/base.py
@@ -26,7 +26,8 @@ class DatadogBaseAction(Action):
         args = {k: v for k, v in kwargs.items()
                 if str(v).strip() and v is not None}
         out = self._run(**args)
-        errors = out.get("errors")
-        if errors:
-            return (False, errors)
+        if isinstance(out, dict):
+            errors = out.get("errors")
+            if errors:
+                return (False, errors)
         return (True, out)

--- a/actions/lib/base.py
+++ b/actions/lib/base.py
@@ -27,7 +27,7 @@ class DatadogBaseAction(Action):
                 if str(v).strip() and v is not None}
         out = self._run(**args)
         if isinstance(out, dict):
-            errors = out.get("errors")
+            errors = out.get("errors", None)
             if errors:
                 return (False, errors)
         return (True, out)

--- a/actions/lib/monitors.py
+++ b/actions/lib/monitors.py
@@ -19,10 +19,10 @@ class DatadogEditMonitor(DatadogBaseAction):
 
 class DatadogGetAllMonitors(DatadogBaseAction):
     def _run(self, **kwargs):
-        _monitor_tags = kwargs.pop("tags","")
-        _group_states = kwargs.pop("group_states","")
-        monitor_tags = [_tag.strip() for _tag in _monitor_tags.split(",")] if _monitor_tags else None
-        group_states = [_state.strip() for _state in group_states] if _group_states else None
+        monitor_tags_raw = kwargs.pop("tags","")
+        group_states_raw = kwargs.pop("group_states","")
+        monitor_tags = [tag.strip() for tag in monitor_tags_raw.split(",")] if monitor_tags_raw else None
+        group_states = [state.strip() for state in group_states_raw] if group_states_raw else None
         return api.Monitor.get_all(monitor_tags=monitor_tags, group_states=group_states, **kwargs)
 
 

--- a/actions/lib/monitors.py
+++ b/actions/lib/monitors.py
@@ -19,7 +19,7 @@ class DatadogEditMonitor(DatadogBaseAction):
 
 class DatadogGetAllMonitors(DatadogBaseAction):
     def _run(self, **kwargs):
-        _monitor_tags = kwargs.pop("monitor_tags","")
+        _monitor_tags = kwargs.pop("tags","")
         _group_states = kwargs.pop("group_states","")
         monitor_tags = [_tag.strip() for _tag in _monitor_tags.split(",")] if _monitor_tags else None
         group_states = [_state.strip() for _state in group_states] if _group_states else None

--- a/actions/lib/monitors.py
+++ b/actions/lib/monitors.py
@@ -18,8 +18,12 @@ class DatadogEditMonitor(DatadogBaseAction):
 
 
 class DatadogGetAllMonitors(DatadogBaseAction):
-    def _run(self):
-        return api.Monitor.get_all()
+    def _run(self, **kwargs):
+        _monitor_tags = kwargs.pop("monitor_tags","")
+        _group_states = kwargs.pop("group_states","")
+        monitor_tags = [_tag.strip() for _tag in _monitor_tags.split(",")] if _monitor_tags else None
+        group_states = [_state.strip() for _state in group_states] if _group_states else None
+        return api.Monitor.get_all(monitor_tags=monitor_tags, group_states=group_states, **kwargs)
 
 
 class DatadogGetMonitor(DatadogBaseAction):

--- a/actions/monitors.get_all_monitors.yaml
+++ b/actions/monitors.get_all_monitors.yaml
@@ -11,7 +11,7 @@ parameters:
   tags:
     type: string
     required: false
-    description: "A comma separated list indicating what tags, if any, should be used to filter the list of monitors by scope. For example: `env:prod,service:abc`"
+    description: "A comma separated list indicating what tags, if any, should be used to filter the list of monitors by scope. Example: 'env:prod,service:abc'"
   cls:
     default: DatadogGetAllMonitors
     immutable: true

--- a/actions/monitors.get_all_monitors.yaml
+++ b/actions/monitors.get_all_monitors.yaml
@@ -11,7 +11,7 @@ parameters:
   tags:
     type: string
     required: false
-    description: "A comma separated list indicating what tags, if any, should be used to filter the list of monitors by scope"
+    description: "A comma separated list indicating what tags, if any, should be used to filter the list of monitors by scope. For example: `env:prod,service:abc`"
   cls:
     default: DatadogGetAllMonitors
     immutable: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - monitoring
   - alerting
   - saas
-version: 1.0.1
+version: 1.0.2
 author: Lisa Bekdache
 email: lisa.bekdache@dailymotion.com
 python_versions:


### PR DESCRIPTION
As reported here: https://github.com/StackStorm-Exchange/stackstorm-datadog/issues/16, this PR implements fix to support filtering on the `monitors.get_all_monitors` action based on already exposed parameters - `tags` and `group_states`. 


Please note: `monitors.get_all_monitors` action internally leverages datadog sdk's `api.Monitor.get_all` function, that returns a list of dictionaries and not just dictionary(json) as expected in the base.py

Testing: 
```
pip list | grep datadog
datadog            0.14.0
```

```
>>> from datadog import initialize
>>> from datadog import api
>>> options = {
...             'api_key': "xxx",
...             'app_key': "xxx",
}
>>>
>>> initialize(**options)
>>>
>>> print(type(api.Monitor.get_all()))
<class 'list'>
```