### PR TITLE
[unblock build] Fix linting in monitors library

### DIFF
--- a/actions/lib/monitors.py
+++ b/actions/lib/monitors.py
@@ -19,11 +19,19 @@ class DatadogEditMonitor(DatadogBaseAction):
 
 class DatadogGetAllMonitors(DatadogBaseAction):
     def _run(self, **kwargs):
-        monitor_tags_raw = kwargs.pop("tags","")
-        group_states_raw = kwargs.pop("group_states","")
-        monitor_tags = [tag.strip() for tag in monitor_tags_raw.split(",")] if monitor_tags_raw else None
-        group_states = [state.strip() for state in group_states_raw] if group_states_raw else None
-        return api.Monitor.get_all(monitor_tags=monitor_tags, group_states=group_states, **kwargs)
+        monitor_tags_raw = kwargs.pop("tags", "")
+        group_states_raw = kwargs.pop("group_states", "")
+        monitor_tags = (
+            [tag.strip() for tag in monitor_tags_raw.split(",")]
+            if monitor_tags_raw
+            else None
+        )
+        group_states = (
+            [state.strip() for state in group_states_raw] if group_states_raw else None
+        )
+        return api.Monitor.get_all(
+            monitor_tags=monitor_tags, group_states=group_states, **kwargs
+        )
 
 
 class DatadogGetMonitor(DatadogBaseAction):


### PR DESCRIPTION
[Build](https://github.com/StackStorm-Exchange/stackstorm-datadog/actions/runs/11064973255/job/30743634791) is failing because of the linting issue and hence blocking new package version release for the commit: https://github.com/StackStorm-Exchange/stackstorm-datadog/pull/17 


```
/home/runner/work/stackstorm-datadog/stackstorm-datadog/pack/actions/lib/monitors.py:22:45: E231 missing whitespace after ','
/home/runner/work/stackstorm-datadog/stackstorm-datadog/pack/actions/lib/monitors.py:23:53: E231 missing whitespace after ','
/home/runner/work/stackstorm-datadog/stackstorm-datadog/pack/actions/lib/monitors.py:24:101: E501 line too long (105 > 100 characters)
```